### PR TITLE
Fix number suffix

### DIFF
--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -1,11 +1,15 @@
 export const numSuffix = (num: number) => {
-  if (num === 1) {
-    return "st";
-  } else if (num === 2) {
-    return "nd";
-  } else if (num === 3) {
-    return "rd";
-  } else {
-    return "th";
+  if (num % 100 < 11 || num % 100 > 19) {
+    switch (num % 10) {
+      case 1:
+        return "st";
+      case 2:
+        return "nd";
+      case 3:
+        return "rd";
+      default:
+        return "th";
+    }
   }
+  return "th";
 };


### PR DESCRIPTION
Fix numSuffix function for cases with the wrong suffix. Site was showing 21th, 22th, 23th, etc.

![image](https://github.com/user-attachments/assets/407f4aff-d712-4bc4-9db3-6b6cf418c01d)
